### PR TITLE
Clusters Name and Clusters Url is not correct

### DIFF
--- a/src/utils/cluster.ts
+++ b/src/utils/cluster.ts
@@ -1,17 +1,15 @@
 const endpoint = {
   http: {
-    devnet: 'http://api-devnet.bbachain.com',
     testnet: 'http://api-testnet.bbachain.com',
-    'mainnet-beta': 'http://api-mainnet.bbachain.com/',
+    mainnet: 'http://api-mainnet.bbachain.com/',
   },
   https: {
-    devnet: 'https://api-devnet.bbachain.com',
     testnet: 'https://api-testnet.bbachain.com',
-    'mainnet-beta': 'https://api-mainnet.bbachain.com/',
+    mainnet: 'https://api-mainnet.bbachain.com/',
   },
 };
 
-export type Cluster = 'devnet' | 'testnet' | 'mainnet-beta';
+export type Cluster = 'testnet' | 'mainnet';
 
 /**
  * Retrieves the RPC API URL for the specified cluster
@@ -20,7 +18,7 @@ export function clusterApiUrl(cluster?: Cluster, tls?: boolean): string {
   const key = tls === false ? 'http' : 'https';
 
   if (!cluster) {
-    return endpoint[key]['devnet'];
+    return endpoint[key]['testnet'];
   }
 
   const url = endpoint[key][cluster];

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -9,14 +9,14 @@ describe('Cluster Util', () => {
     }).to.throw();
   });
 
-  it('devnet', () => {
-    expect(clusterApiUrl()).to.eq('https://api-devnet.bbachain.com');
-    expect(clusterApiUrl('devnet')).to.eq('https://api-devnet.bbachain.com');
-    expect(clusterApiUrl('devnet', true)).to.eq(
-      'https://api-devnet.bbachain.com',
+  it('testnet', () => {
+    expect(clusterApiUrl()).to.eq('https://api-testnet.bbachain.com');
+    expect(clusterApiUrl('testnet')).to.eq('https://api-testnet.bbachain.com');
+    expect(clusterApiUrl('testnet', true)).to.eq(
+      'https://api-testnet.bbachain.com',
     );
-    expect(clusterApiUrl('devnet', false)).to.eq(
-      'http://api-devnet.bbachain.com',
+    expect(clusterApiUrl('testnet', false)).to.eq(
+      'http://api-testnet.bbachain.com',
     );
   });
 });

--- a/test/makeWebsocketUrl.test.ts
+++ b/test/makeWebsocketUrl.test.ts
@@ -23,7 +23,10 @@ const TEST_CASES = [
   ['https://[::]/', 'wss://[::]/'],
   ['https://[::1]/', 'wss://[::1]/'],
   // Increment port if supplied
-  ['https://api-testnet.bbachain.com:80/', 'wss://api-testnet.bbachain.com:81/'],
+  [
+    'https://api-testnet.bbachain.com:80/',
+    'wss://api-testnet.bbachain.com:81/',
+  ],
   ['https://192.168.0.1:443/', 'wss://192.168.0.1:444/'],
   ['https://[::]:8080/', 'wss://[::]:8081/'],
   // No trailing slash

--- a/test/url.ts
+++ b/test/url.ts
@@ -25,5 +25,5 @@ export const Node14Controller = function () {
   return new AbortControllerPolyfill();
 };
 
-//export const url = 'https://api-devnet.bbachain.com/';
-//export const url = 'http://api-devnet.bbachain.com/';
+//export const url = 'https://api-testnet.bbachain.com/';
+//export const url = 'http://api-testnet.bbachain.com/';


### PR DESCRIPTION
Fixes #
* [fix: api cluster name and url](https://github.com/BTI-Labs/web3.js/commit/262ea421cbc0ed914a38c3d846a1edf1e670b509)
* [fix: prettier code](https://github.com/BTI-Labs/web3.js/commit/f48ecd452b728eaf10fa8c7ddb0bceb63c11d04d)